### PR TITLE
Adding Digital Products Helper for Craft Commerce Digital Products

### DIFF
--- a/digitalproductshelper/DigitalProductsHelperPlugin.php
+++ b/digitalproductshelper/DigitalProductsHelperPlugin.php
@@ -1,0 +1,54 @@
+<?php
+namespace Craft;
+
+class DigitalProductsHelperPlugin extends BasePlugin
+{
+    // =========================================================================
+    // PLUGIN INFO
+    // =========================================================================
+
+    public function getName()
+    {
+        return Craft::t('Digital Products - Feed Me Helper');
+    }
+
+    public function getVersion()
+    {
+        return '1.0.0';
+    }
+
+    public function getSchemaVersion()
+    {
+        return '1.0.0';
+    }
+
+    public function getDeveloper()
+    {
+        return 'Argentum Webware';
+    }
+
+    public function getDeveloperUrl()
+    {
+        return 'http://www.argentumwebware.com';
+    }
+
+    public function getPluginUrl()
+    {
+        return 'https://github.com/engram-design/FeedMe-Helpers';
+    }
+
+    public function init()
+    {
+        Craft::import('plugins.digitalproductshelper.integrations.feedme.elementtypes.DigitalProducts_ProductFeedMeElementType');
+    }
+
+    // =========================================================================== //
+    // For compatibility with Feed Me plugin (v2.x)
+
+    public function registerFeedMeElementTypes()
+    {
+        return array(
+            new DigitalProducts_ProductFeedMeElementType(),
+        );
+    }
+}

--- a/digitalproductshelper/integrations/feedme/elementtypes/DigitalProducts_ProductFeedMeElementType.php
+++ b/digitalproductshelper/integrations/feedme/elementtypes/DigitalProducts_ProductFeedMeElementType.php
@@ -1,0 +1,199 @@
+<?php
+namespace Craft;
+
+use Cake\Utility\Hash as Hash;
+
+class DigitalProducts_ProductFeedMeElementType extends BaseFeedMeElementType
+{
+    // Templates
+    // =========================================================================
+
+    public function getGroupsTemplate()
+    {
+        return 'digitalproductshelper/_integrations/feedme/elementtypes/groups';
+    }
+
+    public function getColumnTemplate()
+    {
+        return 'digitalproductshelper/_integrations/feedme/elementtypes/column';
+    }
+
+    public function getMappingTemplate()
+    {
+        return 'digitalproductshelper/_integrations/feedme/elementtypes/map';
+    }
+
+
+    // Public Methods
+    // =========================================================================
+
+    public function getGroups()
+    {
+        return craft()->digitalProducts_productTypes->getEditableProductTypes();
+    }
+
+    public function setModel($settings)
+    {
+        $element = new DigitalProducts_ProductModel();
+        $element->typeId = $settings['elementGroup']['DigitalProducts_Product'];
+
+        if ($settings['locale']) {
+            $element->locale = $settings['locale'];
+        }
+
+        return $element;
+    }
+
+    public function setCriteria($settings)
+    {
+        $criteria = craft()->elements->getCriteria('DigitalProducts_Product');
+        $criteria->status = null;
+        $criteria->limit = null;
+        $criteria->localeEnabled = null;
+
+        $criteria->typeId = $settings['elementGroup']['DigitalProducts_Product'];
+
+        if ($settings['locale']) {
+            $criteria->locale = $settings['locale'];
+        }
+
+        return $criteria;
+    }
+
+    public function matchExistingElement(&$criteria, $data, $settings)
+    {
+        foreach ($settings['fieldUnique'] as $handle => $value) {
+            if ((int)$value === 1) {
+                $feedValue = Hash::get($data, $handle . '.data', $data[$handle]);
+
+                if ($feedValue) {
+                    $criteria->$handle = DbHelper::escapeParam($feedValue);
+                }
+            }
+        }
+
+        // Check to see if an element already exists - interestingly, find()[0] is faster than first()
+        return $criteria->find();
+    }
+
+    public function delete(array $elements)
+    {
+        $return = true;
+
+        foreach ($elements as $element) {
+            if (!craft()->digitalProducts_products->deleteProduct($element)) {
+                $return = false;
+            }
+        }
+
+        return $return;
+    }
+
+    public function prepForElementModel(BaseElementModel $element, array &$data, $settings)
+    {
+        foreach ($data as $handle => $value) {
+            if (is_null($value)) {
+                continue;
+            }
+
+            if (isset($value['data']) && $value['data'] === null) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $dataValue = Hash::get($value, 'data', $value);
+            } else {
+                $dataValue = $value;
+            }
+            
+            switch ($handle) {
+                case 'id':
+                case 'taxCategoryId':
+                case 'price':
+                case 'sku':
+                    $element->$handle = $dataValue;
+                    break;
+                case 'slug':
+                    $element->$handle = ElementHelper::createSlug($dataValue);
+                    break;
+                case 'postDate':
+                case 'expiryDate':
+                    $element->$handle = $this->_prepareDateForElement($dataValue);
+                    break;
+                case 'enabled':
+                case 'freeShipping':
+                case 'promotable':
+                    $element->$handle = (bool)$dataValue;
+                    break;
+                case 'title':
+                    $element->getContent()->$handle = $dataValue;
+                    break;
+                default:
+                    continue 2;
+            }
+
+            // Update the original data in our feed - for clarity in debugging
+            $data[$handle] = $element->$handle;
+        }
+
+        //$this->_populateProductVariantModels($element, $data, $settings);
+
+        return $element;
+    }
+
+    public function save(BaseElementModel &$element, array $data, $settings)
+    {
+        // Are we targeting a specific locale here? If so, we create an essentially blank element
+        // for the primary locale, and instead create a locale for the targeted locale
+        if (isset($settings['locale']) && $settings['locale']) {
+            // Save the default locale element empty
+            $result = craft()->digitalProducts_products->saveProduct($element);
+
+            if ($result) {
+                // Now get the successfully saved (empty) element, and set content on that instead
+                $elementLocale = craft()->digitalProducts_products->getProductById($element->id, $settings['locale']);
+                $elementLocale->setContentFromPost($data);
+
+                // Save the locale entry
+                $result = craft()->digitalProducts_products->saveProduct($elementLocale);
+            }
+        } else {
+            $result = craft()->digitalProducts_products->saveProduct($element);
+        }
+
+        // Because we can have product and variant error, make sure we show them
+        if (!$result) {
+            if ($element->getErrors()) {
+                throw new Exception(json_encode($element->getErrors()));
+            }
+        }
+
+        return $result;
+    }
+
+    public function afterSave(BaseElementModel $element, array $data, $settings)
+    {
+
+    }
+
+
+    // Private Methods
+    // =========================================================================
+
+    private function _prepareDateForElement($date)
+    {
+        $craftDate = null;
+
+        if (!is_array($date)) {
+            $d = date_parse($date);
+            $date_string = date('Y-m-d H:i:s', mktime($d['hour'], $d['minute'], $d['second'], $d['month'], $d['day'], $d['year']));
+
+            $craftDate = DateTime::createFromString($date_string, craft()->timezone);
+        } else {
+            $craftDate = $date;
+        }
+
+        return $craftDate;
+    }
+
+}

--- a/digitalproductshelper/templates/_integrations/feedme/elementtypes/column.html
+++ b/digitalproductshelper/templates/_integrations/feedme/elementtypes/column.html
@@ -1,0 +1,3 @@
+{% set group = craft.digitalProductsHelper.getProductTypeById(feed.elementGroup[elementType]) %}
+
+{{ group.name ?? '' }}

--- a/digitalproductshelper/templates/_integrations/feedme/elementtypes/groups.html
+++ b/digitalproductshelper/templates/_integrations/feedme/elementtypes/groups.html
@@ -1,0 +1,11 @@
+{% set productTypes = craft.feedMe.getElementTypeGroups(elementType) %}
+
+{{ forms.selectField({
+    label: "Digital Product Type" | t,
+    instructions: 'Choose the digital product type you want to to save your feed data into.' | t,
+    id: 'elementGroup-' ~ elementType,
+    name: 'elementGroup[' ~ elementType ~ ']',
+    options: craft.feedme.getSelectOptions(productTypes),
+    value: feed.elementGroup[elementType] ?? '',
+    required: true,
+}) }}

--- a/digitalproductshelper/templates/_integrations/feedme/elementtypes/map.html
+++ b/digitalproductshelper/templates/_integrations/feedme/elementtypes/map.html
@@ -1,0 +1,161 @@
+{% if feed.elementGroup %}
+    {% set productTypeId = feed.elementGroup[elementType] %}
+    {% set productType = craft.digitalProductsHelper.getProductTypeById(productTypeId) %}
+{% endif %}
+
+{% set fields = [{
+    label: 'Title',
+    handle: 'title',
+    default: forms.textField({
+        id: 'fieldDefaults-title',
+        name: 'fieldDefaults[title]',
+        value: feed.fieldDefaults.title ?? '',
+    })
+}, {
+    label: 'Slug',
+    handle: 'slug',
+    instructions: 'If not set, the Slug will be automatically created from Title.' | t,
+}, {
+    label: 'Post Date',
+    handle: 'postDate',
+    instructions: 'Accepts Unix timestamp, or just about any English textual datetime description.' | t,
+    default: forms.dateTimeField({
+        id: 'fieldDefaults-postDate',
+        name: 'fieldDefaults[postDate]',
+        value: feed.fieldDefaults.postDate is defined ? craft.feedme.formatDateTime(feed.fieldDefaults.postDate) : '',
+    })
+}, {
+    label: 'Expiry Date',
+    handle: 'expiryDate',
+    instructions: 'Accepts Unix timestamp, or just about any English textual datetime description.' | t,
+    default: forms.dateTimeField({
+        id: 'fieldDefaults-expiryDate',
+        name: 'fieldDefaults[expiryDate]',
+        value: feed.fieldDefaults.expiryDate is defined ? craft.feedme.formatDateTime(feed.fieldDefaults.expiryDate) : '',
+    })
+}, {
+    label: 'Status',
+    handle: 'enabled',
+    instructions: 'Choose either a default status from the list or the imported field that will contain the status.' | t,
+    default: forms.selectField({
+        id: 'fieldDefaults-enabled',
+        name: 'fieldDefaults[enabled]',
+        value: feed.fieldDefaults.enabled is defined ? feed.fieldDefaults.enabled : '',
+        options: [
+            { label: 'Don\'t import', value: '' },
+            { label: 'Enabled', value: '1' },
+            { label: 'Disabled', value: '0' },
+        ],
+    })
+}, {
+    label: 'Tax Category',
+    handle: 'taxCategoryId',
+    default: forms.selectField({
+        id: 'fieldDefaults-taxCategoryId',
+        name: 'fieldDefaults[taxCategoryId]',
+        value: feed.fieldDefaults.taxCategoryId ?? '1',
+        options: craft.commerce.getTaxCategories(true),
+    })
+}, {
+    label: 'Free Shipping',
+    handle: 'freeShipping',
+    default: forms.checkboxField({
+        id: 'fieldDefaults-freeShipping',
+        name: 'fieldDefaults[freeShipping]',
+        checked: feed.fieldDefaults.freeShipping ?? '',
+    })
+}, {
+    label: 'Promotable',
+    handle: 'promotable',
+    default: forms.checkboxField({
+        id: 'fieldDefaults-promotable',
+        name: 'fieldDefaults[promotable]',
+        checked: feed.fieldDefaults.promotable ?? '',
+    })
+}, {
+    label: 'SKU',
+    handle: 'sku',
+    default: forms.textField({
+        id: 'fieldDefaults-sku',
+        name: 'fieldDefaults[sku]',
+        value: feed.fieldDefaults.sku ?? '',
+    })
+}, {
+    label: 'Price',
+    handle: 'price',
+    default: forms.textField({
+        id: 'fieldDefaults-price',
+        name: 'fieldDefaults[price]',
+        value: feed.fieldDefaults.price ?? '',
+    })
+}, {
+    label: 'Product ID' | t,
+    handle: 'id',
+    instructions: '<strong class="error">Warning: </strong>This should only be used for an existing Craft Commerce Product ID.' | t,
+}] %}
+
+
+<h2>{{ 'Product Fields' | t }}</h2>
+
+<table class="feedme-mapping data fullwidth collapsible">
+    <thead>
+        <th>{{ 'Field' | t }}</th>
+        <th>{{ 'Feed Element' | t }}</th>
+        <th>{{ 'Default Value' | t }}</th>
+    </thead>
+    <tbody>
+        {% for field in fields %}
+            {{ feedMeMacro.generateRow(_context, field) }}
+        {% endfor %}
+    </tbody>
+</table>
+
+<hr>
+
+{% for tab in craft.fields.getLayoutById(productType.fieldLayoutId).getTabs() %}
+    <hr>
+
+    <h2>{{ tab.name }} Fields</h2>
+
+    <table class="feedme-mapping data fullwidth collapsible">
+        <thead>
+            <th>{{ 'Field' | t }}</th>
+            <th>{{ 'Feed Element' | t }}</th>
+            <th>{{ 'Default Value' | t }}</th>
+        </thead>
+        <tbody>
+            {% for fieldtype in tab.getFields() %}
+                {% set field = fieldtype.getField() %}
+
+                {% set variables = { field: field, fieldtype: fieldtype, feed: feed, feedData: feedData } %}
+                {% include 'feedme/_includes/field' with variables %}
+            {% endfor %}
+        </tbody>
+    </table>
+{% endfor %}
+
+<hr>
+
+<h2>{{ "Set a unique identifier for existing elements" | t }}</h2>
+
+<p>{{ "Select the fields you want to use to check for existing elements. When selected, Feed Me will look for existing elements that match the fields provided below and either update, or skip depending on your choice of Import Strategy." | t }}</p>
+
+{% set uniqueFields = fields %}
+
+{% for tab in craft.fields.getLayoutById(productType.fieldLayoutId).getTabs() %}
+    {% for fieldtype in tab.getFields() %}
+        {% set field = fieldtype.getField() %}
+
+        {% set uniqueFields = uniqueFields | merge([{ label: field.name, handle: field.handle }]) %}
+    {% endfor %}
+{% endfor %}
+
+<div class="feedme-uniques">
+    {% for field in uniqueFields %}
+        {{ forms.checkboxField({
+            name: 'fieldUnique[' ~ field.handle ~ ']',
+            label: field.label,
+            checked: feed.fieldUnique[field.handle] ?? '',
+        }) }}
+    {% endfor %}
+</div>

--- a/digitalproductshelper/variables/DigitalProductsHelperVariable.php
+++ b/digitalproductshelper/variables/DigitalProductsHelperVariable.php
@@ -1,0 +1,19 @@
+<?php
+namespace Craft;
+
+/**
+ * Variable class.
+ *
+ * @author    Argentum Webware
+ * @copyright Argentum Webware
+ */
+class DigitalProductsHelperVariable
+{
+
+    // Digital Products doesn't have a getProductTypeById() function
+    public function getProductTypeById($productTypeId)
+    {
+        return craft()->digitalProducts_productTypes->getProductTypeById($productTypeId);
+    }
+
+}


### PR DESCRIPTION
Hi Josh,
I've added the Digital Products helper.
It works as expected and I've uploaded 13000 products across a range of product types.
The only thing I noticed was in the unique field matching. I originally set it to treat SKU as unique but I found that to take forever and eventually fail, nothing was considered unique even though the SKU values were unique in the files.
When I instead chose a combination of 'title' and some other field as a unique match it worked properly.
Cheers
Robb